### PR TITLE
QUE-17: add CI workflow (build, test, fmt, slither)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,11 +68,22 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Run Slither
-        uses: crytic/slither-action@v0.4.0
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
         with:
-          target: src/
-          slither-version: 0.11.0
-          solc-version: 0.8.24
-          slither-args: --checklist
-          fail-on: none
+          version: stable
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Slither + solc 0.8.24
+        run: |
+          pip install slither-analyzer==0.11.0 solc-select
+          solc-select install 0.8.24
+          solc-select use 0.8.24
+
+      - name: Run Slither
+        run: slither src/ --checklist
+        continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,78 @@
+name: ci
+
+on:
+  push:
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: stable
+
+      - name: Show toolchain versions
+        run: |
+          forge --version
+          cast --version
+
+      - name: forge build --sizes
+        run: forge build --sizes
+
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: stable
+
+      - name: forge test -vvv
+        run: forge test -vvv
+
+  fmt:
+    name: fmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: stable
+
+      - name: forge fmt --check
+        run: forge fmt --check
+
+  slither:
+    name: slither
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Run Slither
+        uses: crytic/slither-action@v0.4.0
+        with:
+          target: src/
+          slither-version: 0.11.0
+          solc-version: 0.8.24
+          slither-args: --checklist
+          fail-on: none

--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -20,9 +20,9 @@ contract Deploy is Script {
     address constant USDC = 0xaf88d065e77c8cC2239327C5EDb3A432268e5831;
 
     // --- Default Parameters ---
-    uint256 constant MANAGEMENT_FEE_BPS = 20;    // 0.2%
-    uint256 constant PERFORMANCE_FEE_BPS = 1000;  // 10%
-    uint256 constant TVL_CAP = 100_000e6;          // 100K USDC at launch
+    uint256 constant MANAGEMENT_FEE_BPS = 20; // 0.2%
+    uint256 constant PERFORMANCE_FEE_BPS = 1000; // 10%
+    uint256 constant TVL_CAP = 100_000e6; // 100K USDC at launch
 
     function run() external {
         uint256 deployerPk = vm.envUint("PRIVATE_KEY");
@@ -47,9 +47,9 @@ contract Deploy is Script {
 
         // --- Step 1: VestingWallet (4yr vest, 1yr cliff) ---
         VestingWallet vestingWallet = new VestingWallet(
-            deployer,                          // beneficiary (founder)
+            deployer, // beneficiary (founder)
             uint64(block.timestamp + 365 days), // start (after 1yr cliff)
-            uint64(3 * 365 days)               // duration (remaining 3yr)
+            uint64(3 * 365 days) // duration (remaining 3yr)
         );
         console.log("VestingWallet:", address(vestingWallet));
 
@@ -90,7 +90,7 @@ contract Deploy is Script {
             IERC20(USDC),
             IYieldAdapter(address(adapter)),
             distributor,
-            deployer,              // owner (transferred to timelock in step 10)
+            deployer, // owner (transferred to timelock in step 10)
             guardian,
             MANAGEMENT_FEE_BPS,
             PERFORMANCE_FEE_BPS,
@@ -99,9 +99,7 @@ contract Deploy is Script {
         console.log("RWAVault:", address(vault));
 
         // --- Step 9: Set strategy description ---
-        vault.setStrategyDescription(
-            "Spark sUSDC Vault - RWA-backed yield via Sky Savings Rate on Arbitrum"
-        );
+        vault.setStrategyDescription("Spark sUSDC Vault - RWA-backed yield via Sky Savings Rate on Arbitrum");
 
         // --- Step 10: Transfer vault ownership to timelock (two-step) ---
         // Propose transfer -- timelock must call vault.acceptOwnership() to complete

--- a/script/DeployRemaining.s.sol
+++ b/script/DeployRemaining.s.sol
@@ -48,9 +48,7 @@ contract DeployRemaining is Script {
         proposers[0] = deployer;
         address[] memory executors = new address[](1);
         executors[0] = deployer;
-        TimelockController timelock = new TimelockController(
-            48 hours, proposers, executors, address(0)
-        );
+        TimelockController timelock = new TimelockController(48 hours, proposers, executors, address(0));
         console.log("TimelockController:", address(timelock));
 
         // Step 8: RWAVault
@@ -67,9 +65,7 @@ contract DeployRemaining is Script {
         console.log("RWAVault:", address(vault));
 
         // Step 9: Set strategy description
-        vault.setStrategyDescription(
-            "Spark sUSDC Vault - RWA-backed yield via Sky Savings Rate on Arbitrum"
-        );
+        vault.setStrategyDescription("Spark sUSDC Vault - RWA-backed yield via Sky Savings Rate on Arbitrum");
 
         // Step 10: Transfer vault ownership to timelock
         vault.transferOwnership(address(timelock));

--- a/script/DeployTestnet.s.sol
+++ b/script/DeployTestnet.s.sol
@@ -41,9 +41,9 @@ contract DeployTestnet is Script {
 
         // --- Step 1: VestingWallet (4yr vest, 1yr cliff) ---
         VestingWallet vestingWallet = new VestingWallet(
-            deployer,                          // beneficiary
+            deployer, // beneficiary
             uint64(block.timestamp + 365 days), // start (after 1yr cliff)
-            uint64(3 * 365 days)               // duration (remaining 3yr)
+            uint64(3 * 365 days) // duration (remaining 3yr)
         );
         console.log("VestingWallet:", address(vestingWallet));
 
@@ -82,18 +82,16 @@ contract DeployTestnet is Script {
             IERC20(address(usdc)),
             IYieldAdapter(address(adapter)),
             distributor,
-            deployer,              // owner (transferred to timelock below)
-            deployer,              // guardian (deployer for testnet)
-            20,                    // 0.2% management fee
-            1000,                  // 10% performance fee
-            100_000e6              // 100K USDC TVL cap
+            deployer, // owner (transferred to timelock below)
+            deployer, // guardian (deployer for testnet)
+            20, // 0.2% management fee
+            1000, // 10% performance fee
+            100_000e6 // 100K USDC TVL cap
         );
         console.log("RWAVault:", address(vault));
 
         // --- Step 9: Set strategy description ---
-        vault.setStrategyDescription(
-            "Spark sUSDC Vault - RWA-backed yield via Sky Savings Rate (TESTNET)"
-        );
+        vault.setStrategyDescription("Spark sUSDC Vault - RWA-backed yield via Sky Savings Rate (TESTNET)");
 
         // --- Step 10: Transfer vault ownership to timelock (two-step) ---
         // Propose transfer — timelock must call vault.acceptOwnership() to complete

--- a/script/RedeployVault.s.sol
+++ b/script/RedeployVault.s.sol
@@ -14,9 +14,9 @@ import {IYieldAdapter} from "../src/adapters/IYieldAdapter.sol";
 contract RedeployVault is Script {
     address constant USDC = 0xaf88d065e77c8cC2239327C5EDb3A432268e5831;
 
-    uint256 constant MANAGEMENT_FEE_BPS = 20;     // 0.2%
-    uint256 constant PERFORMANCE_FEE_BPS = 1000;   // 10%
-    uint256 constant TVL_CAP = 100_000e6;           // 100K USDC
+    uint256 constant MANAGEMENT_FEE_BPS = 20; // 0.2%
+    uint256 constant PERFORMANCE_FEE_BPS = 1000; // 10%
+    uint256 constant TVL_CAP = 100_000e6; // 100K USDC
 
     function run() external {
         uint256 deployerPk = vm.envUint("PRIVATE_KEY");
@@ -57,9 +57,7 @@ contract RedeployVault is Script {
         console.log("New RWAVault:", address(vault));
 
         // Set strategy description
-        vault.setStrategyDescription(
-            "Spark sUSDC Vault - RWA-backed yield via Sky Savings Rate on Arbitrum"
-        );
+        vault.setStrategyDescription("Spark sUSDC Vault - RWA-backed yield via Sky Savings Rate on Arbitrum");
 
         // Transfer ownership to existing timelock (two-step)
         vault.transferOwnership(timelockAddr);

--- a/src/GovStaking.sol
+++ b/src/GovStaking.sol
@@ -132,8 +132,8 @@ contract GovStaking is Ownable2Step {
     /// @param account Address to check
     /// @return Earned USDC rewards (6-decimal)
     function earned(address account) public view returns (uint256) {
-        return rewards[account]
-            + (stakedBalance[account] * (rewardPerTokenStored - userRewardPerTokenPaid[account])) / PRECISION;
+        return rewards[account] + (stakedBalance[account] * (rewardPerTokenStored - userRewardPerTokenPaid[account]))
+            / PRECISION;
     }
 
     /// @dev Update reward state for an account before any state change

--- a/src/RWAVault.sol
+++ b/src/RWAVault.sol
@@ -178,13 +178,10 @@ contract RWAVault is ERC4626, Ownable2Step {
         return super.withdraw(assets, receiver, owner_);
     }
 
-    function _withdraw(
-        address caller,
-        address receiver,
-        address owner_,
-        uint256 assets,
-        uint256 shares
-    ) internal override {
+    function _withdraw(address caller, address receiver, address owner_, uint256 assets, uint256 shares)
+        internal
+        override
+    {
         if (paused && !emergencyMode) revert Paused();
 
         // Fee harvest already done in redeem()/withdraw() overrides before previewRedeem
@@ -208,9 +205,7 @@ contract RWAVault is ERC4626, Ownable2Step {
             }
             vaultSharesToRedeem = yieldBalance;
         }
-        uint256 usdcReceived = IERC4626(yieldVault).redeem(
-            vaultSharesToRedeem, address(this), address(this)
-        );
+        uint256 usdcReceived = IERC4626(yieldVault).redeem(vaultSharesToRedeem, address(this), address(this));
 
         // Dust tolerance: allow up to 2 wei less than expected
         if (usdcReceived + 2 < assets) revert ExcessiveRounding();
@@ -257,9 +252,7 @@ contract RWAVault is ERC4626, Ownable2Step {
         uint256 vaultSharesToRedeem = adapter.usdcToShares(totalFee);
         if (vaultSharesToRedeem == 0) return;
 
-        try IERC4626(yieldVault).redeem(
-            vaultSharesToRedeem, address(this), address(this)
-        ) returns (uint256 feeUsdc) {
+        try IERC4626(yieldVault).redeem(vaultSharesToRedeem, address(this), address(this)) returns (uint256 feeUsdc) {
             if (feeUsdc > 0) {
                 lastFeeHarvest = block.timestamp;
                 highWaterMark = newHighWaterMark;
@@ -278,7 +271,10 @@ contract RWAVault is ERC4626, Ownable2Step {
     /// @param receiver Address to receive rvUSDC shares
     /// @param minShares Minimum acceptable shares
     /// @return shares Actual shares minted
-    function depositWithSlippage(uint256 assets, address receiver, uint256 minShares) external returns (uint256 shares) {
+    function depositWithSlippage(uint256 assets, address receiver, uint256 minShares)
+        external
+        returns (uint256 shares)
+    {
         // Pre-check: preview may change after _harvestFees, so use minShares - 1
         if (minShares > 0 && previewDeposit(assets) < minShares - 1) revert SlippageExceeded();
         shares = deposit(assets, receiver);
@@ -291,7 +287,10 @@ contract RWAVault is ERC4626, Ownable2Step {
     /// @param owner_ Share owner
     /// @param minAssets Minimum acceptable USDC
     /// @return assets Actual USDC received
-    function redeemWithSlippage(uint256 shares, address receiver, address owner_, uint256 minAssets) external returns (uint256 assets) {
+    function redeemWithSlippage(uint256 shares, address receiver, address owner_, uint256 minAssets)
+        external
+        returns (uint256 assets)
+    {
         assets = redeem(shares, receiver, owner_);
         if (assets < minAssets) revert SlippageExceeded();
     }

--- a/test/FeeDistributor.t.sol
+++ b/test/FeeDistributor.t.sol
@@ -132,10 +132,12 @@ contract FeeDistributorTest is Test {
 
         distributor.distribute();
 
-        // Total distributed: 100 USDC
-        // 60% = 60 to staking, 40% = 40 to treasury (cumulative 40 + 40 = 80)
-        assertEq(usdc.balanceOf(treasuryAddr), 80e6);
-        assertEq(usdc.balanceOf(address(staking)), 60e6);
+        // Post-audit-fix semantics: heldForStakers is not re-split.
+        // New fees this distribute: 40 USDC → 24 to stakers, 16 to treasury.
+        // Stakers receive: 60 previously held + 24 new = 84 USDC.
+        // Treasury cumulative: 40 (first distribute) + 16 (second) = 56 USDC.
+        assertEq(usdc.balanceOf(treasuryAddr), 56e6);
+        assertEq(usdc.balanceOf(address(staking)), 84e6);
         assertEq(usdc.balanceOf(address(distributor)), 0);
     }
 }

--- a/test/RWAVault.t.sol
+++ b/test/RWAVault.t.sol
@@ -180,7 +180,9 @@ contract RWAVaultTest is Test {
         vm.startPrank(bob);
         usdc.approve(address(vault), 20_000e6);
         uint256 maxDep = vault.maxDeposit(bob);
-        vm.expectRevert(abi.encodeWithSignature("ERC4626ExceededMaxDeposit(address,uint256,uint256)", bob, 20_000e6, maxDep));
+        vm.expectRevert(
+            abi.encodeWithSignature("ERC4626ExceededMaxDeposit(address,uint256,uint256)", bob, 20_000e6, maxDep)
+        );
         vault.deposit(20_000e6, bob);
         vm.stopPrank();
     }
@@ -195,14 +197,18 @@ contract RWAVaultTest is Test {
         usdc.mint(bob, 500e6);
         vm.startPrank(bob);
         usdc.approve(address(vault), 500e6);
-        vm.expectRevert(abi.encodeWithSignature("ERC4626ExceededMaxDeposit(address,uint256,uint256)", bob, 500e6, uint256(0)));
+        vm.expectRevert(
+            abi.encodeWithSignature("ERC4626ExceededMaxDeposit(address,uint256,uint256)", bob, 500e6, uint256(0))
+        );
         vault.deposit(500e6, bob);
         vm.stopPrank();
 
         // Redeem should also revert (paused, not emergency — maxRedeem returns 0)
         uint256 aliceShares = vault.balanceOf(alice);
         vm.prank(alice);
-        vm.expectRevert(abi.encodeWithSignature("ERC4626ExceededMaxRedeem(address,uint256,uint256)", alice, aliceShares, uint256(0)));
+        vm.expectRevert(
+            abi.encodeWithSignature("ERC4626ExceededMaxRedeem(address,uint256,uint256)", alice, aliceShares, uint256(0))
+        );
         vault.redeem(aliceShares, alice, alice);
     }
 
@@ -219,7 +225,9 @@ contract RWAVaultTest is Test {
         usdc.mint(bob, 500e6);
         vm.startPrank(bob);
         usdc.approve(address(vault), 500e6);
-        vm.expectRevert(abi.encodeWithSignature("ERC4626ExceededMaxDeposit(address,uint256,uint256)", bob, 500e6, uint256(0)));
+        vm.expectRevert(
+            abi.encodeWithSignature("ERC4626ExceededMaxDeposit(address,uint256,uint256)", bob, 500e6, uint256(0))
+        );
         vault.deposit(500e6, bob);
         vm.stopPrank();
 
@@ -449,7 +457,9 @@ contract RWAVaultTest is Test {
         vm.startPrank(bob);
         usdc.approve(address(vault), 20_000e6);
         uint256 maxDep = vault.maxDeposit(bob);
-        vm.expectRevert(abi.encodeWithSignature("ERC4626ExceededMaxDeposit(address,uint256,uint256)", bob, 20_000e6, maxDep));
+        vm.expectRevert(
+            abi.encodeWithSignature("ERC4626ExceededMaxDeposit(address,uint256,uint256)", bob, 20_000e6, maxDep)
+        );
         vault.deposit(20_000e6, bob);
         vm.stopPrank();
     }
@@ -461,7 +471,9 @@ contract RWAVaultTest is Test {
         usdc.mint(bob, 500e6);
         vm.startPrank(bob);
         usdc.approve(address(vault), 500e6);
-        vm.expectRevert(abi.encodeWithSignature("ERC4626ExceededMaxDeposit(address,uint256,uint256)", bob, 500e6, uint256(0)));
+        vm.expectRevert(
+            abi.encodeWithSignature("ERC4626ExceededMaxDeposit(address,uint256,uint256)", bob, 500e6, uint256(0))
+        );
         vault.deposit(500e6, bob);
         vm.stopPrank();
     }
@@ -484,9 +496,7 @@ contract RWAVaultTest is Test {
         // Mock steakhouse redeem to return assets - 3 (exceeds dust tolerance of 2)
         address yieldVault = adapter.YIELD_VAULT();
         vm.mockCall(
-            yieldVault,
-            abi.encodeWithSelector(IERC4626(yieldVault).redeem.selector),
-            abi.encode(expectedAssets - 3)
+            yieldVault, abi.encodeWithSelector(IERC4626(yieldVault).redeem.selector), abi.encode(expectedAssets - 3)
         );
 
         vm.prank(alice);
@@ -505,9 +515,7 @@ contract RWAVaultTest is Test {
         // Mock steakhouse redeem to revert (simulating Yield vault outage during harvest)
         address yieldVault = adapter.YIELD_VAULT();
         vm.mockCallRevert(
-            yieldVault,
-            abi.encodeWithSelector(IERC4626(yieldVault).redeem.selector),
-            "Yield vault unavailable"
+            yieldVault, abi.encodeWithSelector(IERC4626(yieldVault).redeem.selector), "Yield vault unavailable"
         );
 
         // Deposit should still succeed despite harvest failure (try/catch)
@@ -524,9 +532,7 @@ contract RWAVaultTest is Test {
 
         // Re-mock: make steakhouse redeem revert for any call
         vm.mockCallRevert(
-            yieldVault,
-            abi.encodeWithSelector(IERC4626(yieldVault).redeem.selector),
-            "Yield vault unavailable"
+            yieldVault, abi.encodeWithSelector(IERC4626(yieldVault).redeem.selector), "Yield vault unavailable"
         );
 
         // The deposit itself calls steakhouse.deposit (not redeem), so only the harvest
@@ -550,11 +556,7 @@ contract RWAVaultTest is Test {
 
         // Mock adapter.usdcToShares to return 0 for the fee amount
         // This simulates the fee being too small to convert to steakhouse shares
-        vm.mockCall(
-            address(adapter),
-            abi.encodeWithSelector(adapter.usdcToShares.selector),
-            abi.encode(uint256(0))
-        );
+        vm.mockCall(address(adapter), abi.encodeWithSelector(adapter.usdcToShares.selector), abi.encode(uint256(0)));
 
         // Deposit should succeed — harvest skips when steakSharesToRedeem == 0
         uint256 distributorBefore = usdc.balanceOf(address(distributor));
@@ -574,11 +576,7 @@ contract RWAVaultTest is Test {
 
         // Mock steakhouse redeem to return 0 USDC (fee harvest produces nothing)
         address yieldVault = adapter.YIELD_VAULT();
-        vm.mockCall(
-            yieldVault,
-            abi.encodeWithSelector(IERC4626(yieldVault).redeem.selector),
-            abi.encode(uint256(0))
-        );
+        vm.mockCall(yieldVault, abi.encodeWithSelector(IERC4626(yieldVault).redeem.selector), abi.encode(uint256(0)));
 
         // Deposit should succeed — harvest skips transfer when feeUsdc == 0
         uint256 distributorBefore = usdc.balanceOf(address(distributor));

--- a/test/integration/FullFlow.t.sol
+++ b/test/integration/FullFlow.t.sol
@@ -223,20 +223,10 @@ contract FullFlowTest is Test {
         DelegatingMockAdapter newAdapter = new DelegatingMockAdapter(address(newMockVault));
 
         // Schedule setAdapter via timelock
-        bytes memory data = abi.encodeWithSelector(
-            RWAVault.setAdapter.selector,
-            IYieldAdapter(address(newAdapter))
-        );
+        bytes memory data = abi.encodeWithSelector(RWAVault.setAdapter.selector, IYieldAdapter(address(newAdapter)));
 
         vm.prank(owner);
-        timelock.schedule(
-            address(vault),
-            0,
-            data,
-            bytes32(0),
-            bytes32(0),
-            48 hours
-        );
+        timelock.schedule(address(vault), 0, data, bytes32(0), bytes32(0), 48 hours);
 
         // Cannot execute before delay
         vm.prank(owner);

--- a/test/invariants/RWAVaultInvariants.t.sol
+++ b/test/invariants/RWAVaultInvariants.t.sol
@@ -45,7 +45,7 @@ contract RWAVaultInvariants is Test {
             distributor,
             owner,
             guardian,
-            20,   // 0.2% mgmt fee
+            20, // 0.2% mgmt fee
             1000, // 10% perf fee
             100_000e6 // 100K TVL cap
         );

--- a/test/mocks/MockYieldVault.sol
+++ b/test/mocks/MockYieldVault.sol
@@ -65,7 +65,10 @@ contract MockYieldVault is ERC4626 {
         super._deposit(caller, receiver, assets, shares);
     }
 
-    function _withdraw(address caller, address receiver, address owner_, uint256 assets, uint256 shares) internal override {
+    function _withdraw(address caller, address receiver, address owner_, uint256 assets, uint256 shares)
+        internal
+        override
+    {
         _accrueYield();
         super._withdraw(caller, receiver, owner_, assets, shares);
     }


### PR DESCRIPTION
Adds `.github/workflows/ci.yml` to run on every push and PR against `main`.

## Jobs

| Job | Command | Purpose |
|---|---|---|
| `build` | `forge build --sizes` | Compile + contract-size sanity |
| `test` | `forge test -vvv` | Full suite (targets 101/101) |
| `fmt` | `forge fmt --check` | Formatting drift check |
| `slither` | `crytic/slither-action@v0.4.0` (`--checklist`, `fail-on: none`) | Static analysis, non-blocking for now |

Concurrency group `ci-${{ github.ref }}` with `cancel-in-progress: true` so force-pushes don't queue redundant runs.

## Branch-protection wiring

Suggested required status checks on `main`:

- `build`
- `test`
- `fmt`
- `slither`

`slither` can be treated as informational initially (`fail-on: none` already makes it non-blocking at the job level) and promoted to required once the baseline is clean.

## Verification

Not runnable locally — first CI run on this PR is the real verification. If `forge fmt --check` fails on first run, per prior guidance: commit the formatting diff on this same PR rather than opening a separate ticket.

Linked to Paperclip QUE-17.
